### PR TITLE
Add foundational research compendium for core modding libs

### DIFF
--- a/developmentplan.md
+++ b/developmentplan.md
@@ -1,0 +1,32 @@
+# Development Plan
+
+## Research Excerpts and Derived Tasks
+The following excerpts are copied directly from the research documents to justify actionable tasks.
+
+### BaseMod Responsibilities
+BaseMod maintains registries for most modded content types:
+- **Cards**: `BaseMod.addCard(AbstractCard card);` plus `UnlockTracker.markCardAsSeen` for compendium visibility.
+- **Relics**: `BaseMod.addRelicToCustomPool(AbstractRelic relic, AbstractCard.CardColor color);` or add to base pools.
+- **Potions**: `BaseMod.addPotion(Class<? extends AbstractPotion> potionClass, Color liquid, Color hybrid, Color spots, String potionID);`
+- **Powers**: use `BaseMod.addPowerJSON` and register via JSON descriptors, or rely on `BaseMod.addPower` for dynamic addition.
+- **Events**: `BaseMod.addEvent(String eventID, Class<? extends AbstractEvent> eventClass, String... actIDs);`
+- **Monsters and Encounters**: `BaseMod.addMonster` and `BaseMod.addBoss`, plus map node overrides.
+- **Keywords**: register from JSON via `BaseMod.addKeyword` or `BaseMod.loadCustomStrings`.
+
+[todo] Design GUI registries mirroring BaseMod content types with validation for IDs, asset presence, and dependency ordering. Ensure guistructure.md references the workflow before implementation.
+
+### ModTheSpire Loader Expectations
+ModTheSpire (MTS) is the primary mod loader for Slay the Spire. It bootstraps JVM instrumentation, loads mod JARs, handles dependency resolution, and provides patching annotations (SpirePatch) that allow mods to inject code into the base game. STSMODDER must reproduce its configuration UI and automation to guarantee that players can assemble mod lists, manage load order, and launch the game seamlessly.
+
+[todo] Implement a launch management module that encapsulates ModTheSpire configuration, including mod selection, dependency ordering, command-line argument generation, and profile persistence. Update guistructure.md accordingly before coding UI.
+
+### StSLib Utility Coverage
+StSLib ships with several gameplay mechanics (e.g., `Freeze`, `Banish`, `Infest`, `Sealed`, etc.). Each mechanic includes pre-defined keywords and helper classes. Mods can opt-in by referencing these keywords and hooking into StSLib's effect classes instead of reinventing them.
+
+[todo] Extend registry and validation logic to surface StSLib mechanics as optional modules, automatically managing keyword inclusion and dependency declarations.
+
+### ActLikeIt Custom Act Support
+ActLikeIt is a Slay the Spire modding library focused on enabling custom acts, events, and dungeon progression tweaks. It augments BaseMod by providing map generation helpers, encounter management utilities, and hooks that bridge acts with vanilla systems. Tools targeting full modding parity must expose ActLikeIt features so creators can design entire acts without writing code manually.
+
+[todo] Plan a visual act editor that outputs ActLikeIt-compliant map generation code, asset packaging, and encounter scheduling.
+

--- a/futures.md
+++ b/futures.md
@@ -1,0 +1,19 @@
+# Futures Roadmap
+
+## Global Plugin Architecture Expansion
+- **Purpose**: Provide a single extensibility surface that exposes BaseMod, ModTheSpire, StSLib, and ActLikeIt APIs to external plugins. This enables third parties to script new workflows, add validators, or extend the GUI without modifying core code.
+- **Usage Notes**:
+  - Define a plugin registry that discovers plugins from a designated directory and injects them with handles to subsystems (registry manager, launch manager, act editor, etc.).
+  - Expose typed interfaces for all major systems: content registries, localization manager, asset pipeline, launch orchestration, validation framework.
+  - Provide lifecycle callbacks (`onLoad`, `onBeforeExport`, `onAfterLaunch`, etc.) so plugins can react to user actions.
+  - Ensure permission controls and sandboxing to prevent malicious plugins from corrupting projects.
+  - Document plugin API in dedicated developer guide once core systems solidify.
+
+## Repository Cloning Automation
+- **Purpose**: Automate cloning of upstream reference repositories (BaseMod, ModTheSpire, StSLib, ActLikeIt) into `research/repos` for offline inspection and keeping parity with upstream changes.
+- **Usage Notes**: Implement a research sync script that fetches or updates repositories, logs commit hashes, and caches documentation snapshots for traceability.
+
+## Research Data Normalization
+- **Purpose**: Convert research markdown files into structured data (JSON/YAML) consumable by the application for inline help and validation rules.
+- **Usage Notes**: Build a parser that extracts requirements (e.g., asset sizes, hook names) and populates configuration tables used by validators and tooltips.
+

--- a/research/actlikeit_full_reference.md
+++ b/research/actlikeit_full_reference.md
@@ -1,0 +1,73 @@
+# ActLikeIt Comprehensive Reference and Tutorial
+
+## Overview
+ActLikeIt is a Slay the Spire modding library focused on enabling custom acts, events, and dungeon progression tweaks. It augments BaseMod by providing map generation helpers, encounter management utilities, and hooks that bridge acts with vanilla systems. Tools targeting full modding parity must expose ActLikeIt features so creators can design entire acts without writing code manually.
+
+## Installation
+1. Download the latest ActLikeIt release JAR and place it inside the `mods/` directory.
+2. Declare the dependency in `ModTheSpire.json` via `"modDependencies": ["actlikeit"]` (in addition to BaseMod/StSLib when needed).
+3. Load order: BaseMod first, then StSLib (if used), ActLikeIt, followed by custom mods.
+
+## Core Capabilities
+
+### Custom Act Framework
+- Provides `CustomDungeon` base class allowing mods to define floors, bosses, events, and map structure.
+- Supports adding entire acts or injecting extra floors between vanilla acts.
+- Handles dynamic floor counts, map node types, and custom icons.
+
+### Map Generation APIs
+- `ActLikeIt.dungeons.CustomDungeon` exposes methods to populate nodes using `MapRoomNode` templates.
+- Utility functions for generating hallway, treasure, rest, shop, event, and elite nodes.
+- Integration with BaseMod's event/monster registries to ensure new encounters appear.
+
+### Dungeon Registration
+- Mods call `DownfallMod.registerAct(CustomDungeon.class, ActInfo info)` (or equivalent API) to introduce acts.
+- Provide metadata such as act ID, name, color, background textures, and boss icons.
+- Supports toggling acts on/off and customizing transitions.
+
+### Encounter Scheduling
+- Helpers to define weighted encounter lists, elite pools, boss rotations, and event selection weights.
+- Works with BaseMod `addMonster`/`addEvent` to ensure compatibility.
+
+### UI and Visual Assets
+- ActLikeIt expects background layers (e.g., sky, ground) in specific resolutions matching vanilla acts.
+- Provides classes to manage cutscenes, map icons, and scene transitions.
+- Tools should enforce asset requirements and preview the generated map.
+
+### Additional Hooks
+- Act-specific settings stored using `SpireConfig` wrappers similar to BaseMod.
+- Patches for run history, compendium entries, and integration with the main menu act selection.
+- Interfaces for intercepting act transitions and customizing player starting states for new acts.
+
+## Tutorial: Building a Custom Act
+1. **Define Resources**: Prepare background images (`BG`, `FG`, etc.), boss icons, map nodes, and event art.
+2. **Create Dungeon Class**: Extend `CustomDungeon` and override methods such as `initialize` (build map), `generateMonsters`, `generateEvents`, and `getActID`.
+3. **Register Acts**: In your mod's initialization (e.g., `receivePostInitialize`), call the ActLikeIt registration method with metadata and event handlers.
+4. **Populate Encounters**: Use BaseMod to register custom monsters and events, then reference them in ActLikeIt encounter pools with weights.
+5. **Customize Map**: Use helper methods to place special nodes (shops, rest sites) and define branching patterns.
+6. **Integrate Story Elements**: Provide act cutscenes, event dialogues, and boss transitions using ActLikeIt-provided classes.
+7. **Test**: Launch the game with ActLikeIt enabled, start a run targeting the custom act, and verify map generation, event triggers, and rewards.
+
+## Integration Points for STSMODDER
+- GUI must allow defining acts via visual map editors, automatically translating to ActLikeIt map generation code.
+- Provide asset uploaders with validation for background/boss textures and map icons.
+- Offer encounter pool designers with weight sliders tied to BaseMod monster/event registries.
+- Manage dependency injection so generated mods automatically include ActLikeIt references and proper load order.
+- Plugin architecture should expose ActLikeIt registries and runtime data (current act, node definitions) for scripted customization.
+
+## Best Practices
+- Keep act IDs unique and consistent with resource folder names.
+- Provide fallback translations for act names and event text.
+- Balance encounters by mixing new and existing monsters to maintain difficulty curves.
+- Use ActLikeIt's helper methods instead of replicating vanilla map generation logic to remain compatible with updates.
+
+## Troubleshooting
+- Map generation errors often stem from missing nodes; ensure each column has at least one path to the next.
+- Asset loading failures arise from incorrect paths or dimensions; validate file structure.
+- Encounter pools referencing unregistered monsters or events cause runtime exceptions; cross-check BaseMod registries first.
+
+## Additional Resources
+- ActLikeIt GitHub documentation and sample custom act mods.
+- Community tutorials on map layout design and act balancing.
+- Downfall mod source code showcasing advanced usage of ActLikeIt features.
+

--- a/research/basemod_full_reference.md
+++ b/research/basemod_full_reference.md
@@ -1,0 +1,134 @@
+# BaseMod Comprehensive Reference and Tutorial
+
+## Overview
+BaseMod is the de-facto modding API for Slay the Spire. It augments the ModTheSpire loader with an extensible subscription model that exposes lifecycle hooks, registries for custom content, shared utilities, and debugging aids like the in-game developer console. Understanding BaseMod is essential for building non-trivial mods or tooling (like STSMODDER) because almost every custom game element flows through its registration and hook mechanisms.
+
+## Installation and Bootstrapping
+1. **Prerequisites**: Install Java (JDK 8+), obtain the Slay the Spire modding base via Steam, and download ModTheSpire.
+2. **Add BaseMod**: Drop the BaseMod JAR into the `mods/` directory used by ModTheSpire.
+3. **Declare Dependency**: In your mod's `ModTheSpire.json`, add `"modDependencies": ["basemod"]` to enforce load ordering.
+4. **Initialize**: Implement a class annotated with `@SpireInitializer` or extend `basemod.BaseMod` and call `BaseMod.subscribe()` to register your mod with the event bus.
+
+### Example Mod Skeleton
+```java
+@SpireInitializer
+public class ExampleMod implements EditCardsSubscriber, PostInitializeSubscriber {
+    public static void initialize() {
+        new ExampleMod();
+    }
+
+    public ExampleMod() {
+        BaseMod.subscribe(this);
+    }
+
+    @Override
+    public void receivePostInitialize() {
+        // UI setup or localization
+    }
+
+    @Override
+    public void receiveEditCards() {
+        // register cards here
+    }
+}
+```
+
+## Core Concepts and Systems
+
+### Subscriber Interfaces and Lifecycle Hooks
+BaseMod exposes numerous interfaces representing hook points in Slay the Spire's runtime. The most common include:
+- `EditCardsSubscriber`, `EditRelicsSubscriber`, `EditStringsSubscriber`, `EditKeywordsSubscriber`: run during the editing stage before the game fully initializes content.
+- `PostInitializeSubscriber`: run after all mods have registered, ideal for UI, badges, and mod settings.
+- `OnStartBattleSubscriber`, `OnCardUseSubscriber`, `PostDrawSubscriber`, etc.: respond to gameplay events.
+- `AddAudioSubscriber`, `AddColorSubscriber`, `PostPowerApplySubscriber`, and many others for specialized needs.
+
+Subscribers can be combined by implementing multiple interfaces in the same class. BaseMod automatically invokes the matching methods at the correct time.
+
+### Content Registries
+BaseMod maintains registries for most modded content types:
+- **Cards**: `BaseMod.addCard(AbstractCard card);` plus `UnlockTracker.markCardAsSeen` for compendium visibility.
+- **Relics**: `BaseMod.addRelicToCustomPool(AbstractRelic relic, AbstractCard.CardColor color);` or add to base pools.
+- **Potions**: `BaseMod.addPotion(Class<? extends AbstractPotion> potionClass, Color liquid, Color hybrid, Color spots, String potionID);`
+- **Powers**: use `BaseMod.addPowerJSON` and register via JSON descriptors, or rely on `BaseMod.addPower` for dynamic addition.
+- **Events**: `BaseMod.addEvent(String eventID, Class<? extends AbstractEvent> eventClass, String... actIDs);`
+- **Monsters and Encounters**: `BaseMod.addMonster` and `BaseMod.addBoss`, plus map node overrides.
+- **Keywords**: register from JSON via `BaseMod.addKeyword` or `BaseMod.loadCustomStrings`.
+
+Each registry enforces unique IDs and may require color associations or additional metadata. STSMODDER must validate ID formats (`modID:ThingName`) and guarantee dependencies (e.g., custom colors before cards).
+
+### Custom Colors and Rarity Pools
+BaseMod allows mods to introduce new card colors (for characters) using `BaseMod.addColor`. This call expects card back textures, energy orb sprites, and attack/skill/power backgrounds in multiple sizes (e.g., `512x512` and `1024x1024`). Cards tied to the new color automatically appear under that pool, while relics can be assigned via `BaseMod.addRelicToCustomPool`.
+
+### Localization and Custom Strings
+Localization strings are loaded via JSON using methods like `BaseMod.loadCustomStrings` and `BaseMod.loadCustomStringsFile`. Each string type (CardStrings, RelicStrings, EventStrings, MonsterStrings, UIStrings, etc.) has expected JSON schema. During `receiveEditStrings`, mods call these methods pointing to language-specific resource paths. STSMODDER must provide editors that generate valid JSON with fallback languages.
+
+### Keywords System
+Keywords are defined in JSON arrays with id, proper name, and synonyms. BaseMod enforces lowercase IDs. Example snippet:
+```json
+[
+  {
+    "PROPER_NAME": "Spark",
+    "NAMES": ["spark", "sparks"],
+    "DESCRIPTION": "Applies a stacking lightning effect."
+  }
+]
+```
+Use `BaseMod.addKeyword(modID, keywordID, names, description);`. Tools should ensure keywords referenced by cards are registered and provide alias linting.
+
+### Developer Console and Commands
+BaseMod ships with an in-game developer console. Mods can define console commands via `DevConsole.registerCommand`. Commands extend `ConsoleCommand` and enable debugging features (e.g., spawn cards, set stats). STSMODDER's launch workflow must expose toggles for enabling the console and listing available commands.
+
+### Save Data and Config
+BaseMod provides `SpireConfig` for storing persistent mod configuration. Config files live under `ModID/Config`. Example usage:
+```java
+SpireConfig config = new SpireConfig("ExampleMod", "config", defaults);
+boolean enabled = config.getBool("enableFeature");
+config.setBool("enableFeature", true);
+config.save();
+```
+A GUI should automatically surface these settings with validation and persistence.
+
+## Advanced Hook Coverage
+- **Combat Events**: `OnCardUseSubscriber`, `PostBattleSubscriber`, `OnPlayerLoseBlockSubscriber`, etc.
+- **Rendering Hooks**: `PostRenderSubscriber`, `RenderSubscriber` to draw overlays.
+- **Dungeon Generation**: `PostCreateStartingDeckSubscriber`, `PostCreateStartingRelicsSubscriber` for custom character loadouts.
+- **Rewards and Screens**: Hooks like `PostCreateShopRelic` allow customizing shops, while `PreStartGameSubscriber` influences run initialization.
+
+A comprehensive tool must cross-reference these hooks when users configure behaviors, ensuring visual editors map to the correct subscriber implementations.
+
+## Tutorial Workflow (End-to-End)
+1. **Create Mod Skeleton**: Use ModTheSpire's template with `@SpireInitializer`.
+2. **Define Mod ID**: Provide a lowercase ID and register using `BaseMod.subscribe`.
+3. **Load Localization**: Implement `receiveEditStrings` to load JSON strings per language.
+4. **Register Keywords**: Parse keywords JSON and call `BaseMod.addKeyword`.
+5. **Add Custom Color (Optional)**: Provide textures and call `BaseMod.addColor`.
+6. **Create Content**: Cards, relics, events, potions, powers, characters, etc., via the relevant subscribers.
+7. **Implement Hooks**: Add gameplay logic by overriding card methods or subscribing to events.
+8. **Testing**: Launch via ModTheSpire with BaseMod and dependencies enabled. Use the dev console and debug commands.
+9. **Packaging**: Ensure `ModTheSpire.json` includes dependencies and versioning.
+
+## Best Practices
+- Maintain unique IDs using `modID:` prefix to avoid collisions.
+- Keep JSON resources under `src/main/resources` using the language directories `eng`, `zhs`, etc.
+- Use `UnlockTracker` APIs to manage logbook visibility.
+- Provide fallback localization for default language to prevent runtime errors.
+- Validate asset resolutions: card faces (250×190), portraits `_p` (500×380), energy orbs (96×96 for UI), etc.
+- Ensure hooking logic respects thread safety and avoids heavy operations in render hooks.
+
+## Integration Points for STSMODDER
+- **Registry Management**: Provide GUI editors that output JSON and class skeletons while ensuring BaseMod API calls are generated.
+- **Hook Visualizers**: Map GUI events to BaseMod interfaces, allowing plugin scripts to inject custom logic.
+- **Dependency Validation**: Confirm BaseMod is present in the launch configuration and warn if version mismatches occur.
+- **Plugin Exposure**: Wrap BaseMod objects (cards, relics, actions) in an API layer accessible from the global plugin architecture so advanced users can script behaviors without editing core code.
+
+## Troubleshooting
+- Missing textures cause runtime `NullPointerException`; double-check resource paths.
+- Forgotten `BaseMod.subscribe(this)` means none of your hooks fire.
+- Keyword JSON errors manifest as localization failures; validate JSON with strict schema.
+- Outdated BaseMod versions may lack newer hooks—check release notes and update dependencies accordingly.
+
+## Additional Learning Resources
+- Official GitHub wiki articles (Custom Cards, Characters, Strings, Keywords, Powers, Events).
+- Community tutorials on card design patterns, custom actions, and balancing.
+- Example mods in the BaseMod repository demonstrating complex integrations (e.g., The Guard, ReplayTheSpire).
+

--- a/research/modthespire_full_reference.md
+++ b/research/modthespire_full_reference.md
@@ -1,0 +1,131 @@
+# ModTheSpire Comprehensive Reference and Tutorial
+
+## Overview
+ModTheSpire (MTS) is the primary mod loader for Slay the Spire. It bootstraps JVM instrumentation, loads mod JARs, handles dependency resolution, and provides patching annotations (SpirePatch) that allow mods to inject code into the base game. STSMODDER must reproduce its configuration UI and automation to guarantee that players can assemble mod lists, manage load order, and launch the game seamlessly.
+
+## Installation Workflow
+1. **Download MTS**: Obtain the latest release and place `ModTheSpire.jar` in the Slay the Spire directory.
+2. **mods Folder**: Create a `mods/` folder next to the JAR. Drop BaseMod, StSLib, ActLikeIt, and custom mod JARs inside.
+3. **Launch**: Run `java -jar ModTheSpire.jar` (or use bundled scripts). The launcher UI allows selecting mods, toggling debug, and specifying Java args.
+4. **Command Line**: `java -jar ModTheSpire.jar --mods BaseMod.jar,MyMod.jar --enable Beta` etc. STSMODDER should wrap both UI and command-line flows.
+
+## Anatomy of an MTS Mod
+Every mod is a fat JAR containing:
+- Compiled classes targeting Java 8 (or compatible).
+- `ModTheSpire.json` manifest describing name, author, version, dependencies, and optional description/credits.
+- Resource files (images, JSON, localization) under `resources/` or `src/main/resources` when using Gradle.
+
+### ModTheSpire.json Keys
+```json
+{
+  "modid": "examplemod",
+  "name": "Example Mod",
+  "author_list": ["You"],
+  "description": "Adds cards and relics.",
+  "version": "1.0.0",
+  "mts_version": "3.30.0",
+  "sts_version": "12-22-2020",
+  "dependencies": ["basemod"],
+  "optional_dependencies": ["stslib"],
+  "modDependencies": ["basemod"],
+  "update_json": "https://.../update.json"
+}
+```
+- `modid` must be lowercase and unique.
+- `mts_version`/`sts_version` ensure compatibility.
+- `dependencies` vs `modDependencies`: loader-level vs BaseMod registries.
+
+## Patching System
+MTS leverages `javassist` to patch base game classes. The patching pipeline involves scanning for annotations at runtime and applying transformations in load order.
+
+### Patch Annotations
+- `@SpirePatch(clz = X.class, method = "methodName")`: Basic patch targeting specific methods.
+- `@SpireInsertPatch(locator = ...)`: Insert custom code at calculated line positions.
+- `@SpirePrefixPatch`, `@SpirePostfixPatch`, `@SpireInsertPatch`: run before, after, or within the target method.
+- `@SpireInstrumentPatch`: Use `ExprEditor` to rewrite bytecode expressions.
+- `@SpireEnum`, `@SpireField`: Inject new enum values or fields.
+
+### Example Prefix Patch
+```java
+@SpirePatch(clz = AbstractPlayer.class, method = "useCard")
+public class ExampleUseCardPatch {
+    @SpirePrefixPatch
+    public static void beforeUse(AbstractPlayer __instance, AbstractCard card, AbstractMonster monster, int energyOnUse) {
+        // Custom logic before the card resolves
+    }
+}
+```
+
+### Locator Example
+```java
+@SpireInsertPatch(locator = Locator.class)
+public static void insert(AbstractPlayer __instance) {
+    // Runs at the located line
+}
+
+private static class Locator extends SpireInsertLocator {
+    @Override
+    public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+        Matcher matcher = new Matcher.MethodCallMatcher(AbstractDungeon.class, "onModifyPower");
+        return LineFinder.findInOrder(ctMethodToPatch, matcher);
+    }
+}
+```
+
+STSMODDER must surface patch creation via visual editors and templates, generating these classes automatically.
+
+## Loader Lifecycle
+1. **Manifest Parsing**: Reads `ModTheSpire.json` for each JAR.
+2. **Dependency Resolution**: Orders mods, ensuring required dependencies load earlier.
+3. **ClassLoader Setup**: Each mod obtains a `URLClassLoader` with parent-first rules.
+4. **Annotation Scan**: All `@Spire*` annotations are processed.
+5. **Mod Initialization**: `@SpireInitializer` methods or `BaseMod.subscribe` flows run.
+6. **Game Launch**: Once patches apply, the vanilla game is started inside the instrumented JVM.
+
+## CLI Arguments
+- `--mods <list>`: Comma-separated JAR names.
+- `--modfolder <path>`: Alternative mods directory.
+- `--config <file>`: Load a saved configuration.
+- `--beta`, `--daily`: Launch in beta or daily mode.
+- `--help`: Print usage.
+- `--enableMods`/`--disableMods`: Quick toggles for saved configs.
+- `--skip-launcher`: Immediately launch using saved configuration.
+
+STSMODDER should serialize launch profiles matching these arguments and allow headless automation.
+
+## Mod Configuration Files
+MTS stores configuration in `preferences/ModTheSpire`. Each mod may also use `SpireConfig` (provided by BaseMod) or custom config files. Provide import/export tooling so users can share setups.
+
+## Debugging and Logs
+- Standard output and error logs go to `ModTheSpire.log`.
+- The loader exposes toggles for enabling debug logging and instrumentation dumps.
+- When patches fail, MTS prints stack traces referencing CtBehavior names; tools should parse and present them in a friendly UI.
+
+## Update JSON
+MTS supports remote update manifests where `update_json` points to metadata describing latest versions and download URLs. STSMODDER should monitor these endpoints to alert users about outdated mods.
+
+## Tutorial: Building a Mod for MTS
+1. **Project Setup**: Use Gradle with `sourceCompatibility = 1.8`. Depend on MTS and BaseMod via local libs.
+2. **Create Manifest**: Fill out `ModTheSpire.json` with dependencies and metadata.
+3. **Implement Patches**: Annotate patch classes as needed.
+4. **Compile & Package**: Use `gradle jar` to produce a mod JAR including resources.
+5. **Deploy**: Copy to `mods/`. Launch ModTheSpire and select the mod.
+6. **Test**: Use BaseMod console and MTS logs to verify patch behavior.
+
+## Integration Requirements for STSMODDER
+- Provide a launch dashboard replicating MTS features (mod selection, order management, Java args, runtime flags).
+- Manage `ModTheSpire.json` creation and validation inside the GUI, ensuring dependencies and versions align.
+- Offer patch authoring tools with automated locator suggestions and preview of transformed bytecode when possible.
+- Integrate update checking and log parsing for real-time feedback.
+- Ensure plugin architecture can hook into loader events, exposing mod metadata, patch graph, and launch states.
+
+## Troubleshooting Tips
+- `javassist.NotFoundException`: Usually missing classpath entries; ensure required game or library classes exist.
+- ClassCast or NoClassDefFound errors: Check load order and dependencies.
+- Update loops: Validate `update_json` format and HTTP availability.
+
+## Further Reading
+- Official ModTheSpire GitHub README and wiki.
+- Example patching tutorials by community members (insertion, instrumentation, adding UI).
+- Source code of the loader (open source) for advanced customization.
+

--- a/research/stslib_full_reference.md
+++ b/research/stslib_full_reference.md
@@ -1,0 +1,70 @@
+# StSLib Comprehensive Reference and Tutorial
+
+## Overview
+StSLib is a community-maintained library that extends BaseMod with shared mechanics, keywords, UI helpers, and utility classes. Many content mods expect StSLib to be present, and it provides reusable abstractions like custom actions, powers, damage types, and patches to base classes that enable advanced behavior. STSMODDER must understand these facilities to offer full-featured mod creation and compatibility.
+
+## Installation
+1. Download the latest StSLib release and place the JAR into the `mods/` folder with ModTheSpire.
+2. Ensure BaseMod is loaded before StSLib; StSLib declares dependencies but order should still be validated.
+3. Add `"modDependencies": ["stslib"]` to mods that rely on its features.
+
+## Feature Categories
+
+### Keywords and Mechanics
+StSLib ships with several gameplay mechanics (e.g., `Freeze`, `Banish`, `Infest`, `Sealed`, etc.). Each mechanic includes pre-defined keywords and helper classes. Mods can opt-in by referencing these keywords and hooking into StSLib's effect classes instead of reinventing them.
+
+### Extended Card Framework
+- **AbstractEasyCard**: Simplifies card creation by bundling common constructor logic, damage, block, magic number handling, and automatic localization lookups.
+- **AbstractEasyRelic**: Provides base functionality for relic triggers with built-in localization fields and texture loading.
+- **AbstractEasyPower**: Handles power textures, localization, and stacking automatically.
+- **Move-based Enemies**: Utilities for enemy intents, extra actions, and animation support.
+
+### Utility Classes
+- **Wiz**: Static helper for retrieving players/monsters, applying powers, dealing damage, etc., reducing boilerplate.
+- **TextureLoader**: Simplifies loading textures with fallback and caching.
+- **ConfigHelper**: Streamlines `SpireConfig` usage.
+- **FastSet** and collections optimized for frequent operations.
+
+### Patching Enhancements
+StSLib introduces patches that add new hooks (e.g., `OnCreateMidCombatCard`) and improvements like dynamic badge support. Tools must recognize these to avoid duplicate patch generation.
+
+### UI Components
+- Custom orb layers, energy panels, and rendering helpers.
+- Tooltip frameworks for multi-line and multi-keyword tooltips.
+- Particle systems (e.g., sparkles, icicles) accessible via simple calls.
+
+### Action Utilities
+StSLib wraps numerous standard actions with helper methods (e.g., `Wiz.atb(new ApplyPowerAction(...))`) and introduces specialized actions for chaining events, handling freeze/burn counters, and more.
+
+## Tutorial: Using StSLib in a Mod
+1. **Setup Dependencies**: Add StSLib jar to your build path and declare dependency in `ModTheSpire.json`.
+2. **Extend Helper Classes**: Instead of using raw `CustomCard`, extend `AbstractEasyCard` to leverage auto-generated values.
+3. **Localization**: Place JSON under `resources/stslib-localization` or integrate with BaseMod's localization pipeline.
+4. **Use Wiz Helpers**: Replace manual `AbstractDungeon.actionManager.addToBottom` with `Wiz.atb` or `Wiz.att`.
+5. **Opt into Mechanics**: For example, apply the `Freeze` power by importing `stslib.powers.FreezePower` and referencing `StSLib.FreezeStrings` for consistent descriptions.
+6. **Register Custom Tooltips**: Use `TooltipInfo` and `TooltipHelper` from StSLib to display rich descriptions.
+7. **Testing**: Ensure StSLib is loaded before your mod to access all features. Use console commands to spawn cards/powers for quick checks.
+
+## Integration Points for STSMODDER
+- Provide toggles to include StSLib mechanics when designing cards or relics, automatically linking required keywords and assets.
+- Offer templates that extend `AbstractEasyCard` or `AbstractEasyPower` when generating source code.
+- Validate that any referenced StSLib mechanic triggers the correct dependency declaration.
+- Surface documentation for StSLib-specific hooks (e.g., freeze interactions, multi-attack utilities) inside the GUI.
+- Ensure plugin architecture can call StSLib helpers without tight coupling by abstracting them through interface adapters.
+
+## Best Practices
+- Keep StSLib version in sync with mods; breaking changes may alter helper class signatures.
+- Avoid duplicating features already provided; reuse StSLib utilities to maintain compatibility.
+- Monitor changelog for new keywords to update localization editors.
+- When packaging, include StSLib in mod lists for players or warn them if missing.
+
+## Troubleshooting
+- Missing StSLib dependency leads to runtime `NoClassDefFoundError`; enforce dependency checks before launch.
+- Keyword mismatches: Ensure custom keywords do not conflict with StSLib-provided ones (use `modID` namespacing).
+- Texture issues: Utilize `TextureLoader` to avoid file path errors.
+
+## Additional Resources
+- StSLib GitHub README and wiki for mechanic definitions and API docs.
+- Community guides demonstrating freeze and banish combos.
+- Example mods like "Replay the Spire" leveraging StSLib extensively.
+


### PR DESCRIPTION
## Summary
- add comprehensive research guides covering BaseMod, ModTheSpire, StSLib, and ActLikeIt with installation, feature, and tutorial details
- establish initial development plan derived from research excerpts with actionable TODO items
- introduce futures roadmap outlining plugin architecture expansion, repo cloning automation, and research data normalization

## Testing
- not run (research and documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68da588bdc8c83279874ee4f44e439da