### PR TITLE
Add Status tab for consolidated runtime overview

### DIFF
--- a/developmentplan.md
+++ b/developmentplan.md
@@ -45,6 +45,18 @@
 > # ActLikeIt
 > ActLikeIt is an extension to the Slay the Spire modding API that allows modders to add new Acts to the game.
 
+[todo] Enhance the Status tab to provide remediation guidance for dependency readiness, leveraging plugin_manager hooks so plugins can append detectors covering BaseMod installation and ModTheSpire runtime expectations.
+> ## Installation ##
+> 1. Copy `target/BaseMod.jar` to your ModTheSpire mods directory. Maven will automatically do this after packaging if your mods directory is located at `../_ModTheSpire/mods` relative to the repo.
+>
+> ### Running Mods ###
+> 1. Run ModTheSpire.
+>     * For Windows, run `MTS.cmd`.
+>     * For Linux, run `MTS.sh`.
+>     * Or run `ModTheSpire.jar` with Java 8.
+> 2. Select the mod(s) you want to use.
+> 3. Press 'Play'.
+
 [complete] Ensure the application embeds JPype lifecycle management to start and stop the JVM exactly once per session and expose the resulting bridge to plugin consumers for test orchestration, referencing JPype's recommended initialization pattern.
 > JPype is an effort to allow python programs full access to Java class libraries.  This is achieved not through re-implementing Python, as Jython/JPython does, but rather through interfacing at the native level in both Virtual Machines.  Eventually, it should be possible to replace Java with Python in many, though not all, situations. (If you are curious about the project, and want to join the JPype project, please join the project on github).
 > 

--- a/futures.md
+++ b/futures.md
@@ -11,3 +11,6 @@ Extend the JPype test orchestrator with scenario scripting so testers can define
 
 ## Plugin Marketplace
 Create a plugin packaging format (signed zip) allowing community distribution. The plugin manager should verify signatures, resolve dependencies, and sandbox plugin execution while still exposing the complete repository API through controlled facades.
+
+## Status Telemetry Integrations
+Extend the Status tab through plugin-provided panels that can subscribe to lifecycle events from `plugin_manager.PluginManager.dispatch_event`. Each plugin should be able to register custom render callbacks contributing Streamlit components to a shared grid, enabling surfaced health checks for BaseMod asset validation, ModTheSpire launch readiness, and StSLib mechanic coverage without touching the core GUI implementation.

--- a/guielements.md
+++ b/guielements.md
@@ -10,6 +10,11 @@
 - **Plugin Registry Table**: Interactive table listing registered plugins, exposed symbols, and health indicators as provided by `plugin_manager.PluginManager`.
 - **Test Suite Runner Panel**: Buttons to trigger baseline smoke tests and mod-specific regression suites managed by `jpypetestorchestrator.JPypeTestOrchestrator`.
 
+[complete] Status Tab Panels
+- **Runtime Overview Metric**: `st.metric` reflecting the active JVM state sourced from `logic.JPypeBridgeController.get_state()` so authors see engine readiness at a glance.
+- **Environment Validation Feed**: Streamlit success/warning callouts generated from `logic.ApplicationLogic.validate_environment()` summarizing dependency availability across BaseMod, ModTheSpire, StSLib, and ActLikeIt paths.
+- **Recent Test Snapshot**: JSON viewer mirroring `st.session_state["last_test_results"]` so the dashboard mirrors the last executed suite outcome without reopening the Tests tab.
+
 [complete] Modal Dialogs
 - **Dependency Guidance Modal**: Streamlit modal presenting BaseMod/ModTheSpire prerequisites with "Do not show again" preference stored in a persistent configuration file.
 

--- a/guistructure.md
+++ b/guistructure.md
@@ -4,6 +4,8 @@
 
 [complete] Provide a central orchestration dashboard with tabs for "JPype Bridge", "Library Status", "Plugin Registry", and "Test Suites" to reflect the runtime lifecycle of the orchestrator and expose quick actions for starting or shutting down the JVM, running integration tests, and inspecting plugin contributions.
 
+[complete] Introduce a top-level "Status" tab ahead of the existing runtime workflow tabs so environment validation, JVM state metrics, and the latest test results move out of the sidebar into a dedicated workspace, with guielements.md kept in sync for the consolidated layout.
+
 [todo] Implement a Streamlit-based log viewer panel that streams structured log records (JPype, plugin system, GUI interactions) with filtering controls for severity, module, and timeframe.
 
 [complete] Create a contextual helper modal describing BaseMod requirements and StSLib dependency interplay, ensuring compliance with the AGENTS instructions about GUI-first documentation and offering a "Do not show again" persistence toggle.


### PR DESCRIPTION
## Summary
- add a top-level Status tab that centralizes environment validation, JVM state, and recent test results
- update sidebar messaging and documentation blueprints to reflect the new layout and future status enhancements
- extend futures and development planning with tasks for plugin-driven status detectors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da752a62e883279aeb75a3f9a9bfe0