### PR TITLE
Document unified workflows tab hierarchy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,8 @@ Adhering to these guidelines is mandatory for all contributions within this repo
   5. Creating a mod that packages or composes other mods generated through the application, including all integration sub-workflows.
   6. Any additional logical workflows and sub-workflows necessary to cover the entire feature surface of BaseMod, ModTheSpire, STSLib, and ActLikeIt.
 
+* All GUI workflows must be consolidated within a dedicated top-level **"Workflows"** tab. Each workflow is represented solely as a sub-tab under this parent, and no workflow-specific UI may exist outside this hierarchy.
+
 ## Data Portability & Schema Governance
 - All project data managed by the application must remain fully importable/exportable via a canonical YAML representation. When new features, data structures, or variables are introduced or modified, update the YAML loader/exporter implementations and the example YAML in the repository root in the same change set.
 - Maintain `featuresvarsanddatastructure.md` as a synchronized catalog of every feature, data structure, and variable, including each item's purpose and its relationships; update it atomically with any related code or documentation change.

--- a/developmentplan.md
+++ b/developmentplan.md
@@ -75,3 +75,5 @@
 [complete] Document and implement a global plugin system that exposes every runtime symbol—classes, functions, instances, configuration values—so plugin authors can extend the tool without monkey patching.
 
 [todo] After delivering the initial orchestration stack, expand research on BaseMod hooks, StSLib additions, and ActLikeIt act definitions to append workflow-specific tasks here.
+
+[todo] Architect the unified "Workflows" parent tab with sub-tabs for every authoring flow, aligning GUI, REST, and plugin hooks so workflow logic lives exclusively within this hierarchy and is fully discoverable via the plugin manager registry.

--- a/futures.md
+++ b/futures.md
@@ -14,3 +14,6 @@ Create a plugin packaging format (signed zip) allowing community distribution. T
 
 ## Status Telemetry Integrations
 Extend the Status tab through plugin-provided panels that can subscribe to lifecycle events from `plugin_manager.PluginManager.dispatch_event`. Each plugin should be able to register custom render callbacks contributing Streamlit components to a shared grid, enabling surfaced health checks for BaseMod asset validation, ModTheSpire launch readiness, and StSLib mechanic coverage without touching the core GUI implementation.
+
+## Workflow Hub Architecture
+Document and implement a Workflows parent tab that dynamically enumerates workflow sub-tabs supplied by core modules and plugins. Provide plugin APIs so extensions can inject new workflow tabs, register dependency metadata, and expose Streamlit renderers while inheriting shared validation and persistence services.

--- a/guielements.md
+++ b/guielements.md
@@ -20,3 +20,6 @@
 
 [complete] Notification System
 - **Toast Notifications**: Streamlit `st.toast` wrappers delivering success/error/warning feedback from orchestrator and plugin operations.
+
+[todo] Workflows Tab Layout
+- **Workflows Parent Tab**: Streamlit tabset labeled "Workflows" that nests all workflow-specific sub-tabs and binds each to its respective orchestrator controllers (character builder, enemy authoring, relic designer, etc.), guaranteeing no workflow UI exists outside the parent tab.

--- a/guistructure.md
+++ b/guistructure.md
@@ -11,3 +11,5 @@
 [complete] Create a contextual helper modal describing BaseMod requirements and StSLib dependency interplay, ensuring compliance with the AGENTS instructions about GUI-first documentation and offering a "Do not show again" persistence toggle.
 
 [todo] Reserve a dedicated area for ModTheSpire launch shortcuts, including jar selection, mod enablement toggles, and validation warnings for missing dependencies, enabling seamless alignment with the development plan's ModTheSpire integration objectives.
+
+[todo] Define a top-level "Workflows" tab containing sub-tabs for every authoring workflow (characters, enemies, cards, relics, potions, acts, composite mods, and future additions), ensuring no workflow panels appear outside this hierarchy and documenting the binding expectations for each sub-tab.


### PR DESCRIPTION
## Summary
- add repository-wide guidance mandating a Workflows parent tab that owns all workflow sub-tabs
- align planning documents (`developmentplan.md`, `guistructure.md`, and `guielements.md`) with the new Workflows hierarchy expectations
- extend the futures roadmap with plans for a plugin-aware workflow hub architecture

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68da798745808327a0389e8cd279da12